### PR TITLE
feat: 그룹 멤버 상세에 일주일 커밋 현황 UI 추가해 멤버 상황 확인 용이하도록 기능 개선

### DIFF
--- a/git-poor-web/package-lock.json
+++ b/git-poor-web/package-lock.json
@@ -2241,13 +2241,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -2605,9 +2605,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4111,9 +4111,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -5444,9 +5444,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/git-poor-web/src/app/(main)/groups/_components/group-member-list.tsx
+++ b/git-poor-web/src/app/(main)/groups/_components/group-member-list.tsx
@@ -86,6 +86,19 @@ export default function GroupMemberList({
               </div>
             </div>
 
+            {/* 7일간의 잔디 현황 */}
+            <div className="flex gap-1 justify-center my-2">
+              {member.recent_commits?.map((hasCommit, idx) => (
+                <div
+                  key={idx}
+                  className={cn(
+                    'w-3 h-3 md:w-4 md:h-4 rounded-sm',
+                    hasCommit ? 'bg-primary' : 'bg-grass-0',
+                  )}
+                />
+              ))}
+            </div>
+
             <Link
               href={previewLink(`/groups/${groupId}/members/${member.user_id}`)}
               className="w-full"

--- a/git-poor-web/src/lib/preview/mock-groups.ts
+++ b/git-poor-web/src/lib/preview/mock-groups.ts
@@ -76,6 +76,7 @@ export const mockGroupMembersOwner: GroupMemberWithCommit[] = [
     current_penalty_count: 2,
     joined_at: '2025-06-15',
     today_commit_count: 5,
+    recent_commits: [true, true, false, true, true, true, true],
   },
   {
     user_id: 'b2c3d4e5-f6a7-8901-bcde-f12345678901',
@@ -89,6 +90,7 @@ export const mockGroupMembersOwner: GroupMemberWithCommit[] = [
     current_penalty_count: 1,
     joined_at: '2025-07-02',
     today_commit_count: 3,
+    recent_commits: [true, false, true, true, false, true, true],
   },
   {
     user_id: 'c3d4e5f6-a7b8-9012-cdef-123456789012',
@@ -102,6 +104,7 @@ export const mockGroupMembersOwner: GroupMemberWithCommit[] = [
     current_penalty_count: 4,
     joined_at: '2025-08-10',
     today_commit_count: 0,
+    recent_commits: [false, false, true, false, false, false, false],
   },
   {
     user_id: 'd4e5f6a7-b8c9-0123-defa-234567890123',
@@ -115,6 +118,7 @@ export const mockGroupMembersOwner: GroupMemberWithCommit[] = [
     current_penalty_count: 0,
     joined_at: '2025-09-20',
     today_commit_count: 7,
+    recent_commits: [true, true, true, true, true, true, true],
   },
 ];
 
@@ -142,6 +146,7 @@ export const mockGroupMembersMember: GroupMemberWithCommit[] = [
     current_penalty_count: 0,
     joined_at: '2025-10-01',
     today_commit_count: 4,
+    recent_commits: [true, true, true, true, false, true, true],
   },
   {
     user_id: PREVIEW_USER_ID,
@@ -155,6 +160,7 @@ export const mockGroupMembersMember: GroupMemberWithCommit[] = [
     current_penalty_count: 0,
     joined_at: '2025-10-05',
     today_commit_count: 5,
+    recent_commits: [true, true, false, true, true, true, true],
   },
   {
     user_id: 'f6a7b8c9-d0e1-2345-fabc-456789012345',
@@ -168,6 +174,7 @@ export const mockGroupMembersMember: GroupMemberWithCommit[] = [
     current_penalty_count: 2,
     joined_at: '2025-10-05',
     today_commit_count: 2,
+    recent_commits: [false, true, true, false, true, false, true],
   },
   {
     user_id: 'a7b8c9d0-e1f2-3456-abcd-567890123456',
@@ -181,6 +188,7 @@ export const mockGroupMembersMember: GroupMemberWithCommit[] = [
     current_penalty_count: 3,
     joined_at: '2025-11-12',
     today_commit_count: 0,
+    recent_commits: [false, false, false, false, true, false, false],
   },
   {
     user_id: 'b8c9d0e1-f2a3-4567-bcde-678901234567',
@@ -194,6 +202,7 @@ export const mockGroupMembersMember: GroupMemberWithCommit[] = [
     current_penalty_count: 1,
     joined_at: '2025-12-01',
     today_commit_count: 1,
+    recent_commits: [true, false, true, false, false, true, false],
   },
 ];
 

--- a/git-poor-web/src/services/group-service.ts
+++ b/git-poor-web/src/services/group-service.ts
@@ -298,30 +298,59 @@ export async function getGroupMembersWithTodayCommitCount(
   // 기존 멤버 목록
   const members: GroupMember[] = await getGroupMembers(groupId);
   if (members.length === 0) return [];
-  const today = getGitPoorDate(new Date().toISOString());
-  const memberIds = members.map((m) => m.user_id);
 
-  // 오늘 커밋 조회 (admin)
-  const { data: rows, error } = await admin
-    .from('commits')
-    .select('user_id')
-    .in('user_id', memberIds)
-    .eq('commit_date', today);
-
-  if (error) {
-    throw new AppError('SERVER_ERROR', '오늘 커밋 조회에 실패했습니다.', error);
+  // 날짜 범위 계산 (오늘 포함 최근 7일)
+  const today = new Date();
+  const dateStrList: string[] = [];
+  for (let i = 6; i >= 0; i--) {
+    const d = new Date(today);
+    d.setDate(today.getDate() - i);
+    dateStrList.push(getGitPoorDate(d.toISOString()));
   }
 
-  // user_id별 카운트
-  const countMap = new Map<string, number>();
+  const startDate = dateStrList[0];
+  const endDate = dateStrList[6];
+
+  const memberIds = members.map((m) => m.user_id);
+
+  // 최근 7일 커밋 조회 (admin)
+  const { data: rows, error } = await admin
+    .from('commits')
+    .select('user_id, commit_date')
+    .in('user_id', memberIds)
+    .gte('commit_date', startDate)
+    .lte('commit_date', endDate);
+
+  if (error) {
+    throw new AppError(
+      'SERVER_ERROR',
+      '최근 7일 커밋 조회에 실패했습니다.',
+      error,
+    );
+  }
+
+  // user_id별, date별 커밋 여부 매핑
+  const commitSet = new Set<string>(); // "userId_date"
+  const todayCountMap = new Map<string, number>();
+
   (rows ?? []).forEach((r: any) => {
-    countMap.set(r.user_id, (countMap.get(r.user_id) ?? 0) + 1);
+    commitSet.add(`${r.user_id}_${r.commit_date}`);
+    if (r.commit_date === endDate) {
+      todayCountMap.set(r.user_id, (todayCountMap.get(r.user_id) ?? 0) + 1);
+    }
   });
 
-  return members.map((m) => ({
-    ...m,
-    today_commit_count: countMap.get(m.user_id) ?? 0,
-  }));
+  return members.map((m) => {
+    const recent_commits = dateStrList.map((date) =>
+      commitSet.has(`${m.user_id}_${date}`),
+    );
+
+    return {
+      ...m,
+      today_commit_count: todayCountMap.get(m.user_id) ?? 0,
+      recent_commits,
+    };
+  });
 }
 
 // 그룹 상세 정보 완성 (그룹 정보 + 멤버 리스트 )

--- a/git-poor-web/src/types/group.ts
+++ b/git-poor-web/src/types/group.ts
@@ -1,5 +1,3 @@
-import { GroupRole } from './role';
-
 export interface GroupSummary {
   id: string;
   name: string;
@@ -38,4 +36,5 @@ export interface GroupDetail {
 
 export interface GroupMemberWithCommit extends GroupMember {
   today_commit_count: number;
+  recent_commits: boolean[];
 }


### PR DESCRIPTION
- 최근 7일(오늘 포함) 커밋 기록을 한 번에 조회하고, 각 멤버의 날짜별 커밋 여부를 boolean 배열로 매핑
- 멤버 카드 중앙에 7일간의 커밋 내역을 보여주는 가로형 잔디 블록(7칸) 추가

